### PR TITLE
Replace FlunksHub with onlyflunks

### DIFF
--- a/src/fixed.ts
+++ b/src/fixed.ts
@@ -14,7 +14,7 @@ export const WINDOW_IDS = {
   ABOUT_US: "about-us",
   FLUNKFOLIO_ITEM: "flunkfolio-item-",
   FLUNK_E_MART: "flunk-e-mart",
-  FLUNKS_HUB: "Flunks_Hub",
+  FLUNKS_HUB: "onlyflunks",
   HOMEBASE: "Homebase",
   FREAK: "freak",
   SEMESTER_0: "semester0Map",
@@ -68,8 +68,8 @@ export const WINDOW_APP_INFO_TO_WINDOW_ID = {
     key: WINDOW_IDS.ABOUT_US,
   },
   [WINDOW_IDS.FLUNKS_HUB]: {
-    appName: "FlunksHub",
-    appIcon: "/images/icons/flunkshub.png",
+    appName: "onlyflunks",
+    appIcon: "/images/icons/onlyflunks.png",
     key: WINDOW_IDS.FLUNKS_HUB,
   },
   [WINDOW_IDS.SEMESTER_0]: {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,7 +13,7 @@ import { animated, config, useSpring } from "@react-spring/web";
 import FlunkEMart from "windows/FlunkMart";
 import useGettingStarted from "store/useGettingStarted";
 import Welcome from "windows/Welcome";
-import FlunksHub from "../windows/FlunksHub";
+import Onlyflunks from "../windows/Onlyflunks";
 import Homebase from "windows/Homebase";
 import Semester0Map from "windows/Semester0Map";
 import DraggableResizeableWindow from "components/DraggableResizeableWindow";
@@ -187,8 +187,8 @@ const windowsMemod = useMemo(() => (
           })}
         />
 
-        <DesktopAppIcon title="FlunksHub" icon="/images/icons/flunkshub.png" 
-        onDoubleClick={() => openWindow({ key: WINDOW_IDS.FLUNKS_HUB, window: <FlunksHub /> })} />
+        <DesktopAppIcon title="onlyflunks" icon="/images/icons/onlyflunks.png"
+        onDoubleClick={() => openWindow({ key: WINDOW_IDS.FLUNKS_HUB, window: <Onlyflunks /> })} />
 
         <DesktopAppIcon
           title="semester zero"

--- a/src/windows/Onlyflunks.tsx
+++ b/src/windows/Onlyflunks.tsx
@@ -4,22 +4,22 @@ import { useWindowsContext } from "contexts/WindowsContext";
 import { WINDOW_IDS } from "fixed";
 import AppLoader from "components/AppLoader";
 
-const FlunksHub: React.FC = () => {
+const Onlyflunks: React.FC = () => {
   const { closeWindow } = useWindowsContext();
 
   return (
     <AppLoader bgImage="/images/loading/bootup.webp">
       <DraggableResizeableWindow
         offSetHeight={44}
-        headerTitle="FlunksHub"
+        headerTitle="onlyflunks"
         windowsId={WINDOW_IDS.FLUNKS_HUB}
         onClose={() => closeWindow(WINDOW_IDS.FLUNKS_HUB)}
         initialWidth="420px"
         initialHeight="300px"
-        headerIcon="/images/icons/flunkshub.png"
+        headerIcon="/images/icons/onlyflunks.png"
       >
         <Frame variant="inside" className="p-4 h-full w-full flex flex-col items-start gap-2">
-          <h3>🧠 Welcome to FlunksHub</h3>
+          <h3>🧠 Welcome to onlyflunks</h3>
           <p>This will be the control center for Flunks interactions.</p>
           <p>Coming soon: quests, upgrades, and secret missions.</p>
         </Frame>
@@ -28,4 +28,4 @@ const FlunksHub: React.FC = () => {
   );
 };
 
-export default FlunksHub;
+export default Onlyflunks;


### PR DESCRIPTION
## Summary
- update FlunksHub window to onlyflunks
- adjust mapping data for onlyflunks
- update desktop icon and import

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430be3c1408325a67f0adbbd9e6e63