### PR TITLE
Fix treehouse click on map

### DIFF
--- a/src/styles/map.module.css
+++ b/src/styles/map.module.css
@@ -21,6 +21,7 @@
   background-repeat: no-repeat;
   z-index: 10;
   cursor: pointer;
+  pointer-events: auto;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -60,6 +61,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   z-index: 5;
+  pointer-events: none;
   transition: opacity 0.3s ease;
 }
 

--- a/src/windows/Semester0Map.tsx
+++ b/src/windows/Semester0Map.tsx
@@ -29,27 +29,29 @@ const { openWindow, closeWindow } = useWindowsContext(); // ✅ ADD THIS
       {hovered && <div className={styles["map-overlay"]} />}
 
       <div
-  className={`${styles.icon} ${styles.treehouse}`}
-  onMouseEnter={() => setHovered('treehouse')}
-  onMouseLeave={() => setHovered(null)}
-  onClick={() =>
-    openWindow({
-      key: WINDOW_IDS.TREEHOUSE_MAIN,
-      window: (
-        <DraggableResizeableWindow
-          windowsId={WINDOW_IDS.TREEHOUSE_MAIN}
-          headerTitle="Treehouse"
-          onClose={() => closeWindow(WINDOW_IDS.TREEHOUSE_MAIN)}
-          initialWidth="100%"
-          initialHeight="100%"
-          resizable={false}
-        >
-          <TreehouseMain />
-        </DraggableResizeableWindow>
-      ),
-    })
-  } 
-/>
+        className={`${styles.icon} ${styles.treehouse}`}
+        onMouseEnter={() => setHovered('treehouse')}
+        onMouseLeave={() => setHovered(null)}
+        onClick={() =>
+          openWindow({
+            key: WINDOW_IDS.TREEHOUSE_MAIN,
+            window: (
+              <DraggableResizeableWindow
+                windowsId={WINDOW_IDS.TREEHOUSE_MAIN}
+                headerTitle="Treehouse"
+                onClose={() => closeWindow(WINDOW_IDS.TREEHOUSE_MAIN)}
+                initialWidth="100%"
+                initialHeight="100%"
+                resizable={false}
+              >
+                <TreehouseMain />
+              </DraggableResizeableWindow>
+            ),
+          })
+        }
+      >
+        🪵
+      </div>
 
       <div
         className={`${styles.icon} ${styles.arcade}`}


### PR DESCRIPTION
## Summary
- ensure overlay doesn't intercept clicks by disabling pointer events
- make the treehouse icon visible like the rest

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find module declarations)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68446fb2cb18832598d47ec8c869e45e