### PR TITLE
Add semester zero map loader

### DIFF
--- a/src/components/SemesterZeroCSSLoader.tsx
+++ b/src/components/SemesterZeroCSSLoader.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import styled, { keyframes } from 'styled-components';
+
+const moveBg = keyframes`
+  0%,30% { background-position: 0 0px; }
+  50%,100% { background-position: 0 -0.1px; }
+`;
+
+const bounce = keyframes`
+  50%,100% { top: 109.5%; }
+`;
+
+const textAnim = keyframes`
+  0%,30% { transform: translateY(0); }
+  80%,100% { transform: translateY(-260%); }
+`;
+
+const Loader = styled.div`
+  width: fit-content;
+  font-size: 17px;
+  font-family: monospace;
+  line-height: 1.4;
+  font-weight: bold;
+  padding: 30px 2px 50px;
+  background: linear-gradient(#000 0 0) 0 0/100% 100% content-box padding-box no-repeat;
+  position: relative;
+  overflow: hidden;
+  animation: ${moveBg} 2s infinite cubic-bezier(1,175,.5,175);
+  color: white;
+`;
+
+const LoadingText = styled.span`
+  display: inline-block;
+  animation: ${textAnim} 2s infinite;
+`;
+
+const Icon = styled.img`
+  position: absolute;
+  width: 34px;
+  height: 28px;
+  top: 110%;
+  left: 50%;
+  transform: translateX(-50%);
+  animation: ${bounce} 2s infinite cubic-bezier(1,175,.5,175);
+`;
+
+const SemesterZeroCSSLoader: React.FC = () => (
+  <Loader>
+    <LoadingText>Loading</LoadingText>
+    <Icon src="/images/icons/semester0-icon.png" alt="Semester Zero" />
+  </Loader>
+);
+
+export default SemesterZeroCSSLoader;

--- a/src/styles/map.module.css
+++ b/src/styles/map.module.css
@@ -92,3 +92,12 @@
   cursor: pointer;
   text-shadow: 1px 1px 3px black;
 }
+.loader-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #000;
+  z-index: 40;
+}

--- a/src/windows/Semester0Map.tsx
+++ b/src/windows/Semester0Map.tsx
@@ -8,6 +8,7 @@ import DinerMain from "windows/Locations/DinerMain";
 import DraggableResizeableWindow from 'components/DraggableResizeableWindow';
 import { WINDOW_IDS } from "fixed";
 import { Button } from 'react95';
+import SemesterZeroCSSLoader from "components/SemesterZeroCSSLoader";
 
 interface Props {
   onClose: () => void;
@@ -16,6 +17,7 @@ interface Props {
 const Semester0Map: React.FC<Props> = ({ onClose }) => {
   const [hovered, setHovered] = useState<string | null>(null);
   const [isPaused, setIsPaused] = useState(false);
+  const [loading, setLoading] = useState(true);
   const { openWindow, closeWindow } = useWindowsContext();
 
   useEffect(() => {
@@ -29,10 +31,20 @@ const Semester0Map: React.FC<Props> = ({ onClose }) => {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, []);
 
+  useEffect(() => {
+    const t = setTimeout(() => setLoading(false), 5000);
+    return () => clearTimeout(t);
+  }, []);
+
   const togglePause = () => setIsPaused(prev => !prev);
 
   return (
     <div className={styles["map-window"]}>
+      {loading && (
+        <div className={styles["loader-overlay"]}>
+          <SemesterZeroCSSLoader />
+        </div>
+      )}
       <img
         src="/images/flunks-map.png"
         className={styles["background-map"]}


### PR DESCRIPTION
## Summary
- add styled Semester Zero loader component
- show loader for 5 seconds when Semester0Map loads

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b18af17c8325934cc9285e766815