### PR TITLE
Remove duplicate Onlyflunks icon

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -187,9 +187,6 @@ const windowsMemod = useMemo(() => (
           })}
         />
 
-        <DesktopAppIcon title="onlyflunks" icon="/images/icons/onlyflunks.png"
-        onDoubleClick={() => openWindow({ key: WINDOW_IDS.FLUNKS_HUB, window: <Onlyflunks /> })} />
-
         <DesktopAppIcon
           title="semester zero"
           icon="/images/icons/semester0-icon.png"


### PR DESCRIPTION
## Summary
- remove the duplicate `onlyflunks` desktop icon and cleanup spacing

## Testing
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_684daa0474788325b670dfefc3fd1bd4