### PR TITLE
Implement Flow login gating for Treehouse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@dynamic-labs/flow": "^3.9.13",
         "@dynamic-labs/sdk-react-core": "^3.8.1",
+        "@onflow/fcl": "^1.10.0",
         "@react-spring/web": "^9.7.3",
         "@react-three/drei": "^9.105.6",
         "@react-three/fiber": "^8.16.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@dynamic-labs/flow": "^3.9.13",
     "@dynamic-labs/sdk-react-core": "^3.8.1",
+    "@onflow/fcl": "^1.10.0",
     "@react-spring/web": "^9.7.3",
     "@react-three/drei": "^9.105.6",
     "@react-three/fiber": "^8.16.5",

--- a/src/components/TreehouseAccess.tsx
+++ b/src/components/TreehouseAccess.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+import * as fcl from "@onflow/fcl";
+import { DynamicWidget } from "@dynamic-labs/sdk-react-core";
+
+const FLUNK_CONTRACT = "0x5643fd47a29770e7";
+const FLOWTY_MARKET_URL = "https://flowty.io/collection/Flunks";
+
+interface Props {
+  onEnter?: () => void;
+}
+
+const TreehouseAccess: React.FC<Props> = ({ onEnter }) => {
+  const [user, setUser] = useState<any>(null);
+  const [hasFlunk, setHasFlunk] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fcl.currentUser().subscribe(setUser);
+  }, []);
+
+  useEffect(() => {
+    if (user?.addr) {
+      checkFlunkOwnership(user.addr);
+    } else {
+      setLoading(false);
+    }
+  }, [user]);
+
+  const checkFlunkOwnership = async (address: string) => {
+    try {
+      const response = await fcl.query({
+        cadence: `
+          import Flunks from ${FLUNK_CONTRACT}
+          import MetadataViews from 0x1d7e57aa55817448
+
+          pub fun main(address: Address): Bool {
+              let acct = getAccount(address)
+              let collection = acct.getCapability(Flunks.CollectionPublicPath)
+                  .borrow<&{NonFungibleToken.CollectionPublic}>()
+                  ?? panic("No collection")
+              return collection.getIDs().length > 0
+          }
+        `,
+        args: (arg: any, t: any) => [arg(address, t.Address)],
+      });
+
+      setHasFlunk(response as boolean);
+    } catch (e) {
+      console.error("Failed to check Flunk ownership:", e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading) return <p>Loading Treehouse...</p>;
+
+  if (!user?.addr) {
+    return (
+      <div>
+        <p>Please login to check Treehouse access:</p>
+        <DynamicWidget />
+      </div>
+    );
+  }
+
+  if (!hasFlunk) {
+    return (
+      <div>
+        <p>You need a Flunk NFT to enter the Treehouse.</p>
+        <a href={FLOWTY_MARKET_URL} target="_blank" rel="noopener noreferrer">
+          <button>Buy a Flunk on Flowty</button>
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <button className="treehouse-button" onClick={onEnter}>
+        Enter the Treehouse
+      </button>
+    </div>
+  );
+};
+
+export default TreehouseAccess;

--- a/src/fcl-config.js
+++ b/src/fcl-config.js
@@ -1,0 +1,8 @@
+import { config } from "@onflow/fcl";
+
+config({
+  "accessNode.api": "https://rest-mainnet.onflow.org",
+  "discovery.wallet": "https://fcl-discovery.onflow.org/authn",
+  "app.detail.title": "Semester Zero",
+  "app.detail.icon": "https://example.com/icon.png",
+});

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,7 +2,7 @@ import { type AppType } from "next/dist/shared/lib/utils";
 import { ThemeProvider } from "styled-components";
 import { GlobalStyles } from "styles/global";
 import original from "react95/dist/themes/original";
-import "config/fcl";
+import "../fcl-config";
 
 import "../styles/globals.css";
 import WindowsProvider from "contexts/WindowsContext";

--- a/src/windows/Semester0Map.tsx
+++ b/src/windows/Semester0Map.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import styles from '../styles/map.module.css';
 import { useWindowsContext } from "contexts/WindowsContext";
 import TreehouseMain from "windows/Locations/TreehouseMain";
+import TreehouseAccess from "../components/TreehouseAccess";
 import ArcadeMain from "windows/Locations/ArcadeMain";
 import MotelMain from "windows/Locations/MotelMain";
 import DinerMain from "windows/Locations/DinerMain";
@@ -57,25 +58,26 @@ const Semester0Map: React.FC<Props> = ({ onClose }) => {
         className={`${styles.icon} ${styles.treehouse}`}
         onMouseEnter={() => setHovered('treehouse')}
         onMouseLeave={() => setHovered(null)}
-        onClick={() =>
-          openWindow({
-            key: WINDOW_IDS.TREEHOUSE_MAIN,
-            window: (
-              <DraggableResizeableWindow
-                windowsId={WINDOW_IDS.TREEHOUSE_MAIN}
-                headerTitle="Treehouse"
-                onClose={() => closeWindow(WINDOW_IDS.TREEHOUSE_MAIN)}
-                initialWidth="100%"
-                initialHeight="100%"
-                resizable={false}
-              >
-                <TreehouseMain />
-              </DraggableResizeableWindow>
-            ),
-          })
-        }
       >
-        🪵
+        <TreehouseAccess
+          onEnter={() =>
+            openWindow({
+              key: WINDOW_IDS.TREEHOUSE_MAIN,
+              window: (
+                <DraggableResizeableWindow
+                  windowsId={WINDOW_IDS.TREEHOUSE_MAIN}
+                  headerTitle="Treehouse"
+                  onClose={() => closeWindow(WINDOW_IDS.TREEHOUSE_MAIN)}
+                  initialWidth="100%"
+                  initialHeight="100%"
+                  resizable={false}
+                >
+                  <TreehouseMain />
+                </DraggableResizeableWindow>
+              ),
+            })
+          }
+        />
       </div>
 
       <div


### PR DESCRIPTION
## Summary
- add `@onflow/fcl` dependency
- configure FCL for mainnet
- create `TreehouseAccess` component checking Flunk NFTs
- integrate new component into `Semester0Map`

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684e9ef60dd88325905e446927a199b2