### PR TITLE
Add flappy leaderboard API

### DIFF
--- a/pages/api/flappyflunk-leaderboard.ts
+++ b/pages/api/flappyflunk-leaderboard.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('flappyflunk_scores')
+      .select('*')
+      .order('score', { ascending: false })
+      .limit(10);
+
+    if (error) {
+      console.error('Error fetching leaderboard:', error);
+      return res.status(500).json({ error: 'Failed to fetch leaderboard' });
+    }
+
+    return res.status(200).json({ scores: data });
+  } catch (err) {
+    console.error('Unexpected error fetching leaderboard', err);
+    return res.status(500).json({ error: 'Unexpected server error' });
+  }
+}


### PR DESCRIPTION
## Summary
- create `pages/api/flappyflunk-leaderboard.ts` API route for getting top 10 scores from Supabase

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850b7feed20832589c8244b77698bcd