### PR TITLE
Implement Select Your Flunk screen

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,7 +12,7 @@ import { animated, config, useSpring } from "@react-spring/web";
 import useGettingStarted from "store/useGettingStarted";
 import Welcome from "windows/Welcome";
 import Onlyflunks from "../windows/Onlyflunks";
-import MyPlace from "windows/MyPlace";
+import { useRouter } from "next/router";
 import Semester0Map from "windows/Semester0Map";
 import DraggableResizeableWindow from "components/DraggableResizeableWindow";
 import FlunksTerminal from "windows/FlunksTerminal";
@@ -64,8 +64,9 @@ const FullScreenLoader = () => {
 };
 
 const Desktop = () => {
-const { windows, openWindow, closeWindow, windowApps } = useWindowsContext();
-const { showGettingStartedOnStartup } = useGettingStarted();
+  const router = useRouter();
+  const { windows, openWindow, closeWindow, windowApps } = useWindowsContext();
+  const { showGettingStartedOnStartup } = useGettingStarted();
 
 useEffect(() => {
   if (showGettingStartedOnStartup) {
@@ -152,7 +153,11 @@ const windowsMemod = useMemo(() => (
           <DesktopAppIcon title="Market" icon="/images/icons/flowty.png" onDoubleClick={() => null} />
         </a>
 
-        <DesktopAppIcon title="MyPlace" icon="/images/icons/myplace.png" onDoubleClick={() => openWindow({ key: WINDOW_IDS.MYPLACE, window: <MyPlace /> })} />
+        <DesktopAppIcon
+          title="MyPlace"
+          icon="/images/icons/myplace.png"
+          onDoubleClick={() => router.push('/select-your-flunk')}
+        />
 
         <DesktopAppIcon
           title="Terminal"

--- a/src/pages/select-your-flunk.tsx
+++ b/src/pages/select-your-flunk.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { Frame, Window, WindowHeader, WindowContent } from "react95";
+import { useDynamicContext } from "@dynamic-labs/sdk-react-core";
+import Image from "next/image";
+
+const characterSlots = [
+  { clique: "geek", imageId: "myplacegeek", label: "Geek" },
+  { clique: "prep", imageId: "myplaceprep", label: "Prep" },
+  { clique: "jock", imageId: "myplacejock", label: "Jock" },
+  { clique: "freak", imageId: "myplacefreak", label: "Freak" },
+];
+
+const SelectYourFlunk: React.FC = () => {
+  const { user, isAuthenticated } = useDynamicContext();
+  const userHasTrait = (clique: string) => {
+    return user?.flunks?.some((nft: any) => nft.traits?.clique === clique);
+  };
+
+  return (
+    <div
+      style={{
+        backgroundImage: `url('/your-background-placeholder.png')`,
+        backgroundSize: "cover",
+        height: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        paddingTop: "3rem",
+      }}
+    >
+      <Window style={{ width: 300, marginBottom: "2rem" }}>
+        <WindowHeader>FlunkOS.EXE</WindowHeader>
+        <WindowContent>
+          Wallet:{" "}
+          {isAuthenticated ? (
+            <span>{user?.walletAddress}</span>
+          ) : (
+            <span>Not connected</span>
+          )}
+        </WindowContent>
+      </Window>
+
+      <h1
+        style={{
+          fontFamily: "Press Start 2P, sans-serif",
+          color: "#fff",
+          marginBottom: "2rem",
+        }}
+      >
+        SELECT YOUR FLUNK
+      </h1>
+
+      <div style={{ display: "flex", gap: "1rem" }}>
+        {characterSlots.map(({ clique, imageId, label }) => {
+          const locked = !userHasTrait(clique);
+          return (
+            <Frame
+              key={clique}
+              variant="well"
+              style={{
+                width: "150px",
+                height: "200px",
+                position: "relative",
+                filter: locked ? "grayscale(100%)" : "none",
+                opacity: locked ? 0.5 : 1,
+                cursor: locked ? "not-allowed" : "pointer",
+              }}
+            >
+              <Image
+                src={`/${imageId}.png`}
+                alt={label}
+                layout="fill"
+                objectFit="contain"
+                style={{ pointerEvents: "none" }}
+              />
+            </Frame>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default SelectYourFlunk;


### PR DESCRIPTION
## Summary
- create `/select-your-flunk` page to show a retro character select
- link the MyPlace desktop icon to the new page

## Testing
- `npm run lint` *(fails: prompts for setup)*
- `npm run build` *(fails: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_685307f03a3483259ed5046f157a5b39