### PR TITLE
Fix Onlyflunks header login status

### DIFF
--- a/src/windows/YourStudents.tsx
+++ b/src/windows/YourStudents.tsx
@@ -38,7 +38,9 @@ const YourStudents: React.FC = () => {
     <AppLoader bgImage="/images/loading/onlyflunks.webp">
       <DraggableResizeableWindow
         offSetHeight={44}
-        headerTitle={`Onlyflunks - ${user?.username || "Not Logged In"}`}
+        headerTitle={`Onlyflunks - ${
+          user?.username || (user ? "Logged In" : "Not Logged In")
+        }`}
         authGuard={true}
         windowsId={WINDOW_IDS.YOUR_STUDENTS}
         onClose={() => {


### PR DESCRIPTION
## Summary
- improve header title for the Onlyflunks window

## Testing
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68553a8e37a883259e0d41ab56c766da