### PR TITLE
Add BootScreen component

### DIFF
--- a/src/components/BootScreen.module.css
+++ b/src/components/BootScreen.module.css
@@ -1,0 +1,46 @@
+.bootWrapper {
+  width: 100vw;
+  height: 100vh;
+  background: #000;
+  color: #00ff00;
+  font-family: "Courier New", Courier, monospace;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bootWindow {
+  border: 2px solid #00ff00;
+  box-shadow: 0 0 10px #00ff00;
+  padding: 20px;
+}
+
+.bootLog {
+  white-space: pre-wrap;
+  text-align: left;
+}
+
+.logoWrapper {
+  width: 100vw;
+  height: 100vh;
+  background: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@keyframes glow {
+  0% {
+    filter: drop-shadow(0 0 2px #00ff00);
+  }
+  50% {
+    filter: drop-shadow(0 0 10px #00ff00);
+  }
+  100% {
+    filter: drop-shadow(0 0 2px #00ff00);
+  }
+}
+
+.logoGlow {
+  animation: glow 2s ease-in-out infinite;
+}

--- a/src/components/BootScreen.tsx
+++ b/src/components/BootScreen.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from "react";
+import styles from "./BootScreen.module.css";
+
+type BootScreenProps = {
+  onComplete: () => void;
+};
+
+const bootMessages = [
+  "Initializing Flunk OS v0.95…",
+  "Mounting Disk: flunkfolio.DAT…",
+  "Spinning Up Gumball Machine…",
+  "Connecting to Market Node…",
+  "Loading Discord Gateway…",
+  "Boot Sequence Complete.",
+];
+
+const BootScreen: React.FC<BootScreenProps> = ({ onComplete }) => {
+  const [index, setIndex] = useState(0);
+  const [showLogo, setShowLogo] = useState(false);
+  const [audioPlayed, setAudioPlayed] = useState(false);
+
+  useEffect(() => {
+    if (index < bootMessages.length) {
+      const t = setTimeout(() => setIndex((i) => i + 1), 900);
+      return () => clearTimeout(t);
+    } else {
+      const t = setTimeout(() => setShowLogo(true), 1000);
+      return () => clearTimeout(t);
+    }
+  }, [index]);
+
+  useEffect(() => {
+    if (showLogo && !audioPlayed) {
+      const audio = new Audio("/sounds/win95-boot.wav");
+      audio.play().catch(() => {});
+      setAudioPlayed(true);
+      const t = setTimeout(() => {
+        onComplete();
+      }, 3000);
+      return () => clearTimeout(t);
+    }
+  }, [showLogo, audioPlayed, onComplete]);
+
+  if (showLogo) {
+    return (
+      <div className={styles.logoWrapper}>
+        <img src="/flunks-logo.png" alt="Flunks Logo" className={styles.logoGlow} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.bootWrapper}>
+      <div className={styles.bootWindow}>
+        <div className={styles.bootLog}>
+          {bootMessages.slice(0, index).map((msg, i) => (
+            <div key={i}>{msg}</div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BootScreen;

--- a/src/components/DesktopMain.tsx
+++ b/src/components/DesktopMain.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const DesktopMain: React.FC = () => {
+  return (
+    <div className="flex items-center justify-center w-screen h-screen bg-gray-800 text-white">
+      Desktop Main
+    </div>
+  );
+};
+
+export default DesktopMain;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,15 @@
+import React, { useState } from "react";
+import BootScreen from "components/BootScreen";
+import DesktopMain from "components/DesktopMain";
+
+const Home: React.FC = () => {
+  const [booted, setBooted] = useState(false);
+
+  return booted ? (
+    <DesktopMain />
+  ) : (
+    <BootScreen onComplete={() => setBooted(true)} />
+  );
+};
+
+export default Home;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,6 +22,7 @@ import FlappyFlunkWindow from "windows/Games/FlappyFlunkWindow";
 
 
 import RadioPlayer from "components/RadioPlayer";
+import BootScreen from "components/BootScreen";
 
 const FullScreenLoader = () => {
   const [percent, setPercent] = useState(0);
@@ -246,8 +247,24 @@ const MonitorScreenWrapper: React.FC<React.PropsWithChildren> = ({ children }) =
 
 const Home: NextPage = () => {
   const [isMounted, setIsMounted] = useState(false);
-  useEffect(() => { setIsMounted(true); }, []);
+  const [bootComplete, setBootComplete] = useState(false);
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
   if (!isMounted) return null;
+
+  if (!bootComplete) {
+    return (
+      <>
+        <Head>
+          <title>Flunks</title>
+          <meta name="description" content="Welcome to the Flunks Highschool computer." />
+          <link rel="icon" href="/images/logos/os-logo.png" />
+        </Head>
+        <BootScreen onComplete={() => setBootComplete(true)} />
+      </>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary
- create BootScreen component and module CSS
- demo DesktopMain and show BootScreen usage in Home.tsx
- show BootScreen on initial index page load

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850b59ae2388325a17ccc6ab61ca0e5