### PR TITLE
Add FHS school app

### DIFF
--- a/src/pages/fhs-school.tsx
+++ b/src/pages/fhs-school.tsx
@@ -1,0 +1,32 @@
+import Head from 'next/head';
+import { Button, Toolbar, Window, WindowContent, WindowHeader } from 'react95';
+import React from 'react';
+
+const FHSSchoolPage: React.FC = () => (
+  <>
+    <Head>
+      <title>Flunks High School</title>
+    </Head>
+    <div className="flex flex-col items-center min-h-screen py-8 bg-[#008080] gap-4">
+      <Window className="w-full max-w-xl">
+        <WindowHeader className="flex justify-between items-center">
+          <span>Flunks High School</span>
+        </WindowHeader>
+        <Toolbar className="flex gap-2 p-2">
+          <Button>School Calendar</Button>
+          <Button>Staff</Button>
+          <Button>Resources</Button>
+          <Button>School Map</Button>
+        </Toolbar>
+        <WindowContent>
+          <p>
+            Welcome to Flunks High School! This is a fun, fictitious campus
+            created for the Flunks community.
+          </p>
+        </WindowContent>
+      </Window>
+    </div>
+  </>
+);
+
+export default FHSSchoolPage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -161,6 +161,12 @@ const windowsMemod = useMemo(() => (
         />
 
         <DesktopAppIcon
+          title="FHS"
+          icon="/images/icons/open-book.png"
+          onDoubleClick={() => router.push('/fhs-school')}
+        />
+
+        <DesktopAppIcon
           title="Terminal"
           icon="/images/icons/terminal.png"
           onDoubleClick={() => openWindow({


### PR DESCRIPTION
## Summary
- add a new `/fhs-school` page with placeholder buttons
- create a desktop icon that links to the new page

## Testing
- `npm run lint` *(fails: Next.js prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_685df5105d008325833d35020d368c19