### PR TITLE
Fix BootScreen placement and add fade out

### DIFF
--- a/src/components/BootScreen.module.css
+++ b/src/components/BootScreen.module.css
@@ -7,6 +7,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1001;
 }
 
 .bootWindow {
@@ -27,6 +31,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1001;
 }
 
 @keyframes glow {
@@ -43,4 +51,17 @@
 
 .logoGlow {
   animation: glow 2s ease-in-out infinite;
+}
+
+@keyframes fadeout {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+.fadeOut {
+  animation: fadeout 1s forwards;
 }

--- a/src/components/BootScreen.tsx
+++ b/src/components/BootScreen.tsx
@@ -17,6 +17,7 @@ const BootScreen: React.FC<BootScreenProps> = ({ onComplete }) => {
   const [index, setIndex] = useState(0);
   const [showLogo, setShowLogo] = useState(false);
   const [audioPlayed, setAudioPlayed] = useState(false);
+  const [fadeOut, setFadeOut] = useState(false);
 
   useEffect(() => {
     if (index < bootMessages.length) {
@@ -34,22 +35,31 @@ const BootScreen: React.FC<BootScreenProps> = ({ onComplete }) => {
       audio.play().catch(() => {});
       setAudioPlayed(true);
       const t = setTimeout(() => {
-        onComplete();
+        setFadeOut(true);
       }, 3000);
       return () => clearTimeout(t);
     }
-  }, [showLogo, audioPlayed, onComplete]);
+  }, [showLogo, audioPlayed]);
+
+  useEffect(() => {
+    if (fadeOut) {
+      const t = setTimeout(() => {
+        onComplete();
+      }, 1000); // match fade-out duration
+      return () => clearTimeout(t);
+    }
+  }, [fadeOut, onComplete]);
 
   if (showLogo) {
     return (
-      <div className={styles.logoWrapper}>
+      <div className={`${styles.logoWrapper} ${fadeOut ? styles.fadeOut : ''}`}>
         <img src="/flunks-logo.png" alt="Flunks Logo" className={styles.logoGlow} />
       </div>
     );
   }
 
   return (
-    <div className={styles.bootWrapper}>
+    <div className={`${styles.bootWrapper} ${fadeOut ? styles.fadeOut : ''}`}>
       <div className={styles.bootWindow}>
         <div className={styles.bootLog}>
           {bootMessages.slice(0, index).map((msg, i) => (


### PR DESCRIPTION
## Summary
- ensure BootScreen is positioned on top of the start bar
- add fade-out animation when boot finishes

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: aborted)*

------
https://chatgpt.com/codex/tasks/task_e_685ea9c7b3a48325a9d80d9f84221d30