### PR TITLE
Fix mobile map drag

### DIFF
--- a/src/styles/map.module.css
+++ b/src/styles/map.module.css
@@ -2,9 +2,21 @@
   position: relative;
   width: 100%;
   height: 100vh;
-  overflow: hidden;
+  overflow: auto;
   background-color: black;
   font-family: sans-serif;
+  touch-action: none;
+  cursor: grab;
+}
+
+.dragging {
+  cursor: grabbing;
+}
+
+.map-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
 }
 
 .background-map {
@@ -103,14 +115,12 @@
 }
 
 @media (max-width: 768px) {
-  .map-window {
-    overflow-x: auto;
-    overflow-y: hidden;
+  .map-inner {
     width: calc(100vh * 16 / 9);
   }
 
   .background-map {
-    width: calc(100vh * 16 / 9);
+    width: 100%;
     height: 100vh;
     object-fit: contain;
   }

--- a/src/windows/Semester0Map.tsx
+++ b/src/windows/Semester0Map.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import styles from '../styles/map.module.css';
 import { useWindowsContext } from "contexts/WindowsContext";
 import TreehouseMain from "windows/Locations/TreehouseMain";
@@ -19,6 +19,7 @@ const Semester0Map: React.FC<Props> = ({ onClose }) => {
   const [isPaused, setIsPaused] = useState(false);
   const [loading, setLoading] = useState(true);
   const { openWindow, closeWindow } = useWindowsContext();
+  const mapRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -38,20 +39,66 @@ const Semester0Map: React.FC<Props> = ({ onClose }) => {
 
   const togglePause = () => setIsPaused(prev => !prev);
 
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    let isDown = false;
+    let startX = 0;
+    let scrollLeft = 0;
+
+    const start = (e: MouseEvent | TouchEvent) => {
+      isDown = true;
+      startX = 'touches' in e ? e.touches[0].clientX : e.clientX;
+      scrollLeft = map.scrollLeft;
+      map.classList.add(styles['dragging']);
+    };
+
+    const move = (e: MouseEvent | TouchEvent) => {
+      if (!isDown) return;
+      const x = 'touches' in e ? e.touches[0].clientX : e.clientX;
+      map.scrollLeft = scrollLeft - (x - startX);
+    };
+
+    const stop = () => {
+      isDown = false;
+      map.classList.remove(styles['dragging']);
+    };
+
+    map.addEventListener('mousedown', start);
+    map.addEventListener('mousemove', move);
+    map.addEventListener('mouseup', stop);
+    map.addEventListener('mouseleave', stop);
+    map.addEventListener('touchstart', start);
+    map.addEventListener('touchmove', move);
+    map.addEventListener('touchend', stop);
+
+    return () => {
+      map.removeEventListener('mousedown', start);
+      map.removeEventListener('mousemove', move);
+      map.removeEventListener('mouseup', stop);
+      map.removeEventListener('mouseleave', stop);
+      map.removeEventListener('touchstart', start);
+      map.removeEventListener('touchmove', move);
+      map.removeEventListener('touchend', stop);
+    };
+  }, []);
+
   return (
-    <div className={styles["map-window"]}>
+    <div className={styles["map-window"]} ref={mapRef}>
       {loading && (
         <div className={styles["loader-overlay"]}>
           <SemesterZeroCSSLoader />
         </div>
       )}
-      <img
-        src="/images/flunks-map.png"
-        className={styles["background-map"]}
-        alt="Semester 0 Map"
-      />
+      <div className={styles["map-inner"]}>
+        <img
+          src="/images/flunks-map.png"
+          className={styles["background-map"]}
+          alt="Semester 0 Map"
+        />
 
-      {hovered && <div className={styles["map-overlay"]} />}
+        {hovered && <div className={styles["map-overlay"]} />}
 
       <div
         className={`${styles.icon} ${styles.treehouse}`}
@@ -170,6 +217,7 @@ const Semester0Map: React.FC<Props> = ({ onClose }) => {
       )}
 
       <button className={styles["close-btn"]} onClick={onClose}>✖</button>
+      </div>
 
       {/* Pause Overlay */}
       {isPaused && (


### PR DESCRIPTION
## Summary
- enable drag scrolling on the Semester0 map by resizing the inner map and scrolling the outer container
- update map markup with new map-inner wrapper
- adjust mobile styles and cursor handling

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eaba6798c832597212bb7b6952adc