### PR TITLE
Fix icon layout on mobile

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -86,7 +86,10 @@ const windowsMemod = useMemo(() => (
 
   return (
     <>
-      <div className="flex relative flex-col max-h-[calc(100vh-64px)] w-full flex-wrap items-start gap-4 content-start">
+      <div
+        className="flex relative flex-col w-full flex-wrap items-start gap-4 content-start overflow-y-auto"
+        style={{ maxHeight: "calc(100vh - 64px - var(--safe-area-inset-bottom))" }}
+      >
         <DesktopAppIcon
           title="OnlyFlunks"
           icon="/images/icons/onlyflunks.png"


### PR DESCRIPTION
## Summary
- keep home screen icons above the task bar on mobile

## Testing
- `npm run lint` *(fails: Next.js ESLint wizard prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6867bcf12c048325bdee8b7037c6e3a5