### PR TITLE
Investigate missing story so far cut scene

### DIFF
--- a/src/components/StoryManual.tsx
+++ b/src/components/StoryManual.tsx
@@ -125,7 +125,7 @@ const PlayIcon = styled.div`
 // Sample chapter data - this would come from your game state/progress
 const sampleChapters: Chapter[] = [
   {
-    id: 'homecoming',
+    id: 'story-so-far',
     title: 'The Story So Far 📖',
     subtitle: 'The sky looked different back then. Maybe it was brighter… or maybe I just had younger eyes.',
     unlocked: true,


### PR DESCRIPTION
Correct chapter ID for "The Story So Far" to ensure it displays in public mode.

The chapter was incorrectly assigned the ID `homecoming`, which was filtered out in public mode by existing logic that only shows `homecoming` chapters in build mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-48c49cac-8c0c-4d38-8c71-dabe27a44c58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-48c49cac-8c0c-4d38-8c71-dabe27a44c58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

