### PR TITLE
Debug leaderboard high score update logic

### DIFF
--- a/src/windows/Games/FlunkJumpWindow.tsx
+++ b/src/windows/Games/FlunkJumpWindow.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useSWRConfig } from 'swr';
 import * as fcl from '@onflow/fcl';
 import styled from 'styled-components';
 import { useWindowsContext } from 'contexts/WindowsContext';
@@ -161,6 +162,7 @@ const FlunkJumpWindow = () => {
   const [gameStarted, setGameStarted] = useState(false);
   const [sfxEnabled, setSfxEnabled] = useState(true);
   const { openWindow, closeWindow } = useWindowsContext();
+  const { mutate } = useSWRConfig();
 
   const openLeaderboard = (e: React.MouseEvent) => {
     e.stopPropagation(); // Prevent triggering the start game
@@ -223,6 +225,13 @@ const FlunkJumpWindow = () => {
           })
           .then(data => {
             console.log('✅ Flunky Uppy score submitted successfully to leaderboard:', data);
+            // Proactively refresh the leaderboard cache so repeated higher scores appear immediately
+            try {
+              mutate('/api/flunky-uppy-leaderboard');
+              console.log('🔄 Leaderboard revalidated after score submission');
+            } catch (e) {
+              console.log('⚠️ Failed to trigger leaderboard refresh:', e);
+            }
           })
           .catch(error => {
             console.error('❌ Flunky Uppy score submission failed:', error);

--- a/src/windows/Games/FlunkyUppyLeaderboardWindow.tsx
+++ b/src/windows/Games/FlunkyUppyLeaderboardWindow.tsx
@@ -1,4 +1,5 @@
 import useSWR from 'swr';
+import { useEffect } from 'react';
 import {
   Frame,
   Table,
@@ -34,7 +35,19 @@ const FlunkyUppyLeaderboardWindow: React.FC = () => {
     data: response,
     error,
     isValidating,
-  } = useSWR<LeaderboardResponse>('/api/flunky-uppy-leaderboard', fetcher);
+    mutate,
+  } = useSWR<LeaderboardResponse>('/api/flunky-uppy-leaderboard', fetcher, {
+    revalidateOnFocus: true,
+    dedupingInterval: 2000,
+  });
+
+  // Lightweight polling to keep the board current after repeated submissions
+  useEffect(() => {
+    const id = setInterval(() => {
+      mutate();
+    }, 10000); // every 10s
+    return () => clearInterval(id);
+  }, [mutate]);
 
   const isLoading = !response && !error;
   const scores = response?.leaderboard || [];


### PR DESCRIPTION
Ensure Flunky Uppy leaderboard updates immediately after a new high score and refreshes periodically.

The backend correctly stored all scores, but the leaderboard UI suffered from a caching issue, preventing new high scores from appearing until the window was reopened. This PR adds explicit revalidation after score submission and periodic polling to keep the leaderboard fresh.

---
<a href="https://cursor.com/background-agent?bcId=bc-58d5e5a7-cfeb-457d-8744-7a618cadc454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-58d5e5a7-cfeb-457d-8744-7a618cadc454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

