### PR TITLE
Arrange main locations in rows of four

### DIFF
--- a/src/styles/map.module.css
+++ b/src/styles/map.module.css
@@ -1323,6 +1323,15 @@
   align-items: center;
 }
 
+/* Grid layout for build mode: show 4 icons per row */
+.nav-buttons-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 20px;
+  align-items: center;
+  justify-items: center;
+}
+
 .nav-icon {
   position: relative;
   width: 70px;
@@ -1510,6 +1519,13 @@
   .nav-buttons {
     gap: 15px;
     justify-content: center;
+  }
+
+  /* Keep 4 per row on build site even on mobile */
+  .nav-buttons-grid {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 14px 12px; /* row and column gaps */
+    justify-items: center;
   }
   
   .nav-icon {

--- a/src/windows/Semester0Map.tsx
+++ b/src/windows/Semester0Map.tsx
@@ -665,7 +665,7 @@ const Semester0Map: React.FC<Props> = ({ onClose }) => {
       <div className={styles["bottom-nav"]}>
         <div className={styles["nav-section"]}>
           <h3>Main Locations</h3>
-          <div className={styles["nav-buttons"]}>
+          <div className={`${styles["nav-buttons"]} ${buildMode === 'build' ? styles["nav-buttons-grid"] : ''}`}>
             {/* Build mode only: upcoming locations (hidden on public) */}
             {buildMode === 'build' && (
               <>


### PR DESCRIPTION
Apply a 4-column grid layout to Main Locations on the build site to prevent icons from being squished.

---
<a href="https://cursor.com/background-agent?bcId=bc-6461ed61-bd5e-45a8-b1db-936f34e80bd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6461ed61-bd5e-45a8-b1db-936f34e80bd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

